### PR TITLE
Allow F3:repeat to iterate over arrays or Traversables

### DIFF
--- a/template.php
+++ b/template.php
@@ -370,7 +370,7 @@ class F3markup extends Base {
 								$this->syms['_'.$cvar]=NULL;
 							$out.='<?php '.
 								(isset($cvar)?('$_'.$cvar.'=0; '):'').
-								'if (is_array('.$gstr.')):'.
+								'if (is_array('.$gstr.') || '.$gstr.' instanceof Traversable):'.
 								'foreach (('.$gstr.'?:array()) as '.
 								(isset($kvar)?('$_'.$kvar.'=>'):'').
 									'$_'.$vvar.'):'.


### PR DESCRIPTION
This (one line) change allows the F3 template tag

```
<F3:repeat>
```

"group" attribute to be an array _or_ a Traversable object (e.g. a DB cursor), allowing us to iterate over anything that is possible to use with `foreach()`
